### PR TITLE
Add KUT and LWV links to permanent footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,6 +2,8 @@
   <ul>
     <li><a href="/about">About</a></li>
     <li><a href="/learn/municipal-bonds">Learn About Bonds</a></li>
+    <li><a href="http://www.kut.org/post/what-are-propositions-austin-voters-will-decide-november-its-alphabet-soup">KUT Article</a></li>
+    <li><a href="https://lwvaustin.org/voter-guide/">League of Women Voters Guide</a></li>
   </ul>
   <p>
     All content licensed as <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY</a> from


### PR DESCRIPTION
@benhamill What do you think about this?

I wanted to elevate the other journalism that has taken on the same scope (all props).

This is what it looks like:

<img width="955" alt="screen shot 2018-10-14 at 9 20 02 am" src="https://user-images.githubusercontent.com/1401/46918034-67e47380-cf92-11e8-82b6-7ae5bf1d234b.png">
