### PR TITLE
Favicon Force Refresh

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,8 +7,8 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ " /feed.xml " | prepend: site.baseurl | prepend: site.url }}">
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png?v=1">
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png?v=1">
     <link rel="manifest" href="/manifest.json">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
I think most browsers cache favicons aggressively and by URL, so I've added some garbage to the end of the favicon paths to try to bust caches. So that I can see our cool new favicon.

Favicons don't work locally for me at all, so I have no idea if this'll actually work. 🙃